### PR TITLE
Add fast falling clock power-up

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         <span>🌟 レベル: <span id="level">1</span></span>
         <span>🎯 宝物を探そう！</span>
         <span>🗝️ 残り宝箱: <span id="treasure-count"></span></span>
+        <span>⏱️ 残り時間: <span id="time">30</span>秒</span>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Display remaining time in the game header
- Introduce falling clock items, including a rare fast version
- Catching a clock grants +1 second to the countdown

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68b252435e2c8330af4db92b0ac3c6f6