### PR TITLE
Limit item spawn rate

### DIFF
--- a/main.js
+++ b/main.js
@@ -310,10 +310,19 @@ const GameEngine = {
   },
 
   startItemSpawn() {
-    GameState.itemSpawnId = setInterval(() => {
+    let spawnCount = 0;
+    const spawn = () => {
       if (GameState.gameOver || GameState.gameClear) return;
       this.spawnItem();
-    }, 2000);
+      spawnCount++;
+      if (spawnCount >= 3 && GameState.itemSpawnId) {
+        clearInterval(GameState.itemSpawnId);
+        GameState.itemSpawnId = null;
+      }
+    };
+
+    spawn();
+    GameState.itemSpawnId = setInterval(spawn, 20000);
   },
 
   spawnItem() {


### PR DESCRIPTION
## Summary
- spawn falling clock items only up to three times within the first minute

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b25535a6ac8330a612c5b61583ea18